### PR TITLE
Add interactive task animations

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,10 +36,11 @@ document.addEventListener('DOMContentLoaded', () => {
         completedTasks.textContent = completed;
     }
 
-    function startEdit(span, index) {
+    function startEdit(span, index, li) {
         const input = document.createElement('input');
         input.type = 'text';
         input.value = tasks[index].text;
+        li.classList.add('editing');
         span.replaceWith(input);
         input.focus();
 
@@ -50,6 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             span.textContent = tasks[index].text;
             input.replaceWith(span);
+            li.classList.remove('editing');
             saveTasks();
             renderTasks(currentFilter);
         };
@@ -98,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
             li.appendChild(editBtn);
             li.appendChild(deleteBtn);
             tasksList.appendChild(li);
-            li.classList.add('fade-in');
+            li.classList.add('slide-in');
 
             checkbox.addEventListener('change', (e) => {
                 tasks[index].completed = e.target.checked;
@@ -109,18 +111,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
             deleteBtn.addEventListener('click', () => {
                 if (confirm('¿Eliminar esta tarea?')) {
-                    li.classList.add('fade-out');
+                    li.classList.add('slide-out');
                     setTimeout(() => {
                         tasks.splice(index, 1);
                         saveTasks();
                         renderTasks(filter);
                         updateStats();
-                    }, 300);
+                    }, 400);
                 }
             });
 
-            editBtn.addEventListener('click', () => startEdit(span, index));
-            span.addEventListener('dblclick', () => startEdit(span, index));
+            editBtn.addEventListener('click', () => startEdit(span, index, li));
+            span.addEventListener('dblclick', () => startEdit(span, index, li));
         });
     }
 
@@ -179,10 +181,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     clearCompletedBtn.addEventListener('click', () => {
         if (confirm('¿Eliminar todas las tareas completadas?')) {
-            tasks = tasks.filter(task => !task.completed);
-            saveTasks();
-            renderTasks(currentFilter);
-            updateStats();
+            const items = document.querySelectorAll('.task-item.completed');
+            items.forEach(li => li.classList.add('slide-out'));
+            setTimeout(() => {
+                tasks = tasks.filter(task => !task.completed);
+                saveTasks();
+                renderTasks(currentFilter);
+                updateStats();
+            }, 400);
         }
     });
 

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,15 @@ button:hover {
     background: #f8f9fa;
     margin-bottom: 0.5rem;
     border-radius: 5px;
+    transition: background 0.3s, transform 0.3s;
+}
+
+.task-item:hover {
+    transform: translateX(5px);
+}
+
+.task-item.editing {
+    background: #fff3cd;
 }
 
 .task-item.completed {
@@ -169,12 +178,30 @@ body.dark .task-item.completed {
     to { opacity: 0; height: 0; margin: 0; padding: 0; }
 }
 
+@keyframes slideIn {
+    from { transform: translateY(-10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes slideOut {
+    from { transform: translateY(0); opacity: 1; height: auto; }
+    to { transform: translateY(10px); opacity: 0; height: 0; margin: 0; padding: 0; }
+}
+
 .fade-in {
     animation: fadeIn 0.3s ease forwards;
 }
 
 .fade-out {
     animation: fadeOut 0.3s ease forwards;
+}
+
+.slide-in {
+    animation: slideIn 0.4s ease forwards;
+}
+
+.slide-out {
+    animation: slideOut 0.4s ease forwards;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add styling for editing state and slide animations
- animate task creation, deletion, and clearing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853023c745c832da87f136828d04201